### PR TITLE
Update vdmj.properties

### DIFF
--- a/resources/vdmj.properties
+++ b/resources/vdmj.properties
@@ -6,17 +6,17 @@
 vdmj.parser.comment_nesting = 3
 
 # External readers <.suffix>=<class> pairs 
-vdmj.parser.external_readers = null
+#vdmj.parser.external_readers = null
 
 # The package list for annotation classes to load.
 # (default "com.fujitsu.vdmj.ast.annotations;annotations.ast")
-vdmj.annotations.packages = com.fujitsu.vdmj.ast.annotations;annotations.ast	
+vdmj.annotations.packages = com.fujitsu.vdmj.ast.annotations;annotations.ast
 
 # Enable annotation debugging (default false)
 vdmj.annotations.debug = false
 
 # An alternative search path for the ClassMapper (default null)
-vdmj.mapping.search_path = null
+#vdmj.mapping.search_path = null
 
 # Skip the check for mutually-recursive function calls (default false)
 vdmj.tc.skip_recursive_check = false


### PR DESCRIPTION
Removed spaces and commented properties which defaults to null in the vdmj.properties file.
Closes #159 