### PR TITLE
Add settings to launch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1123,6 +1123,16 @@
                                     "measureChecks": true
                                 },
                                 "properties": {
+                                    "precision": {
+                                        "type": "number",
+                                        "description": "Precision level if using high precision (ignored for regular precision).",
+                                        "default": 100
+                                    },
+                                    "enableLogging": {
+                                        "type": "boolean",
+                                        "description": "Log real-time events.",
+                                        "default": false
+                                    },
                                     "dynamicTypeChecks": {
                                         "type": "boolean",
                                         "description": "Type check values during interpretation of a VDM model.",

--- a/vdm_test_files/PacemakerRT/PacemakerRT.launch
+++ b/vdm_test_files/PacemakerRT/PacemakerRT.launch
@@ -1,17 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.overture.ide.vdmrt.debug.launchConfigurationType">
-<intAttribute key="vdm_debug_session_id" value="1"/>
-<booleanAttribute key="vdm_launch_config_create_coverage" value="true"/>
-<booleanAttribute key="vdm_launch_config_enable_logging" value="false"/>
-<stringAttribute key="vdm_launch_config_memory_option" value=""/>
-<stringAttribute key="vdm_launch_config_remote_control_class" value=""/>
-<booleanAttribute key="vdm_launch_config_remote_debug" value="false"/>
-<stringAttribute key="vdm_launch_config_project" value="PacemakerRT"/>
-<stringAttribute key="vdm_launch_config_expression" value="new World(&quot;tests/scenarioGoodHeart.arg&quot;,&lt;DOO&gt;).Run()"/>
-<booleanAttribute key="vdm_launch_config_static_method" value="false"/>
-<stringAttribute key="vdm_launch_config_default" value="World"/>
-<stringAttribute key="vdm_launch_config_method" value="Run()"/>
-<stringAttribute key="vdm_launch_config_module" value="World(&quot;tests/scenarioGoodHeart.arg&quot;,&lt;DOO&gt;)"/>
-<booleanAttribute key="vdm_launch_config_enable_realtime_logging" value="true"/>
-<booleanAttribute key="vdm_launch_config_enable_realtime_time_inv_checks" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/PacemakerRT"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <intAttribute key="vdm_debug_session_id" value="1"/>
+    <booleanAttribute key="vdm_launch_config_console_entry" value="false"/>
+    <booleanAttribute key="vdm_launch_config_create_coverage" value="true"/>
+    <stringAttribute key="vdm_launch_config_custom_debugger_properties" value="diags.guards = false;diags.timestep = false;maxint = 255;minint = 0;numeric.type.bind.generation = false;parser.tabstop = 1;rt.cycle.default = 2;rt.duration.default = 2;rt.duration.transactions = false;rt.log.instvarchanges = false;rt.max.periodic.overlaps = 20;scheduler.fcfs.timeslice = 10;scheduler.jitter = 0;scheduler.virtual.timeslice = 10000;traces.max.repeats = 5"/>
+    <stringAttribute key="vdm_launch_config_default" value="World"/>
+    <booleanAttribute key="vdm_launch_config_dtc_checks" value="true"/>
+    <booleanAttribute key="vdm_launch_config_enable_logging" value="false"/>
+    <booleanAttribute key="vdm_launch_config_enable_realtime_logging" value="true"/>
+    <booleanAttribute key="vdm_launch_config_enable_realtime_time_inv_checks" value="false"/>
+    <stringAttribute key="vdm_launch_config_expression" value="new World(&quot;tests/scenarioGoodHeart.arg&quot;,&lt;DOO&gt;).Run()"/>
+    <booleanAttribute key="vdm_launch_config_inv_checks" value="true"/>
+    <booleanAttribute key="vdm_launch_config_measure_checks" value="true"/>
+    <stringAttribute key="vdm_launch_config_memory_option" value=""/>
+    <stringAttribute key="vdm_launch_config_method" value="Run()"/>
+    <stringAttribute key="vdm_launch_config_module" value="World(&quot;tests/scenarioGoodHeart.arg&quot;,&lt;DOO&gt;)"/>
+    <booleanAttribute key="vdm_launch_config_post_checks" value="true"/>
+    <booleanAttribute key="vdm_launch_config_pre_checks" value="true"/>
+    <stringAttribute key="vdm_launch_config_project" value="PacemakerRT"/>
+    <stringAttribute key="vdm_launch_config_remote_control_class" value=""/>
+    <booleanAttribute key="vdm_launch_config_remote_debug" value="false"/>
+    <booleanAttribute key="vdm_launch_config_show_vm_settings" value="false"/>
+    <booleanAttribute key="vdm_launch_config_static_method" value="false"/>
 </launchConfiguration>


### PR DESCRIPTION
Adds the following settings to the launch configuration:

- precision: The precision level if using high precision (ignored for regular precision).
- enableLogging: Enable logging of real-time events.

Closes #158 